### PR TITLE
Fixed issue - [DEPRECATION] `object.send_later(:method)` is deprecated. Use `object.delay.method"

### DIFF
--- a/lib/backgrounded/handler/delayed_job_handler.rb
+++ b/lib/backgrounded/handler/delayed_job_handler.rb
@@ -6,7 +6,7 @@ module Backgrounded
     # see http://github.com/tobi/delayed_job/tree/master
     class DelayedJobHandler
       def request(object, method, *args)
-        object.send_later(method.to_sym, *args)
+        object.delay.send(method.to_sym, *args)
       end
     end
   end


### PR DESCRIPTION
https://github.com/wireframe/backgrounded/issues#issue/5
