### PR TITLE
Handle method name collision

### DIFF
--- a/lib/backgrounded/handler/resque_handler.rb
+++ b/lib/backgrounded/handler/resque_handler.rb
@@ -23,7 +23,7 @@ module Backgrounded
       private
       def self.find_instance(clazz, id, method)
         clazz = clazz.constantize
-        clazz.respond_to?(method) ? clazz : clazz.find(id)
+        id.to_i == -1 ? clazz : clazz.find(id)
       end
       def instance_identifiers(object)
         instance, id = if object.is_a?(Class) 


### PR DESCRIPTION
Changes to avoid the situation where, if an instance and a class method have the same name, a backgrounded call for the instance method would instead invoke the class method.
