### PR TITLE
Remove Rails Dependency Issues

### DIFF
--- a/backgrounded.gemspec
+++ b/backgrounded.gemspec
@@ -13,7 +13,8 @@ Gem::Specification.new do |spec|
   spec.description = %q{Execute any ActiveRecord Model method in the background}
   spec.homepage    = 'http://github.com/wireframe/backgrounded'
 
-  spec.add_runtime_dependency 'rails', '>= 3.0.0'
+  spec.add_runtime_dependency 'activerecord', '>= 3.0.0'
+  spec.add_runtime_dependency 'activesupport', '>= 3.0.0'
 
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/backgrounded.rb
+++ b/lib/backgrounded.rb
@@ -1,6 +1,7 @@
 require 'logger'
 require_relative 'backgrounded/handler/inprocess_handler'
 require_relative 'backgrounded/object_extensions'
+require_relative 'backgrounded/active_record_extension'
 require_relative 'backgrounded/railtie' if defined?(Rails)
 
 module Backgrounded

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-require 'rails'
 require 'active_record'
+require 'yaml'
 require_relative 'support/setup_database'
 require 'backgrounded'
 


### PR DESCRIPTION
Rails is not really needed in the dependencies since you really only need Active Record for the Active Record Extension, and Active Support for the Concern.

I removed Rails as a dependency and put `activerecord` and `activesupport` in its place, limiting the dependencies that are needed.
